### PR TITLE
Remove blank choice from company sector

### DIFF
--- a/directory_validators/constants/choices.py
+++ b/directory_validators/constants/choices.py
@@ -9,7 +9,6 @@ AIMS = (
 )
 
 COMPANY_CLASSIFICATIONS = (
-    ('', ''),
     ('AEROSPACE', 'Aerospace'),
     ('AGRICULTURE_HORTICULTURE_AND_FISHERIES', 'Agriculture, Horticulture and Fisheries'),
     ('AIRPORTS', 'Airports'),


### PR DESCRIPTION
This change removes the blank first option:

![image](https://cloud.githubusercontent.com/assets/5485798/19833539/6d72d118-9e3c-11e6-9a09-f88387cb6a0c.png)
